### PR TITLE
Fixes for yupgi_alert

### DIFF
--- a/Traits/Conditions/GrantTimedConditionOnDeploy.cs
+++ b/Traits/Conditions/GrantTimedConditionOnDeploy.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.AS.Traits
 			return order.OrderString == "GrantConditionOnDeploy" && deployState == TimedDeployState.Ready ? info.Voice : null;
 		}
 
-		void Deploy()
+		public void Deploy()
 		{
 			// Something went wrong, most likely due to deploy order spam and the fact that this is a delayed action.
 			if (deployState != TimedDeployState.Ready)


### PR DESCRIPTION
This change is needed to use AS and https://github.com/forcecore/yupgi_alert0 in the same mod.

See also: https://github.com/forcecore/yupgi_alert0/pull/87.